### PR TITLE
Add io.containerd.image.sandbox annotation for overriding sandbox (pause) image

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_run_linux.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux.go
@@ -17,6 +17,7 @@
 package podsandbox
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -37,7 +38,7 @@ import (
 	criutil "github.com/containerd/containerd/v2/internal/cri/util"
 )
 
-func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
+func (c *Controller) sandboxContainerSpec(ctx context.Context, id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
@@ -194,7 +195,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		specOpts = append(specOpts, customopts.WithAnnotation(pKey, pValue))
 	}
 
-	specOpts = append(specOpts, annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
+	specOpts = append(specOpts, annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(ctx, config), config, true)...)
 
 	return c.runtimeSpec(id, "", specOpts...)
 }

--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -438,7 +438,7 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			if test.configChange != nil {
 				test.configChange(config)
 			}
-			spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
+			spec, err := c.sandboxContainerSpec(context.Background(), testID, config, imageConfig, nsPath, nil)
 			if test.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, spec)

--- a/internal/cri/server/podsandbox/sandbox_run_other.go
+++ b/internal/cri/server/podsandbox/sandbox_run_other.go
@@ -19,6 +19,8 @@
 package podsandbox
 
 import (
+	"context"
+
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -27,9 +29,9 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
+func (c *Controller) sandboxContainerSpec(ctx context.Context, id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
-	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
+	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(ctx, config), config, true)...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for

--- a/internal/cri/server/podsandbox/sandbox_run_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_test.go
@@ -17,6 +17,7 @@
 package podsandbox
 
 import (
+	"context"
 	goruntime "runtime"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestSandboxContainerSpec(t *testing.T) {
 			if test.imageConfigChange != nil {
 				test.imageConfigChange(imageConfig)
 			}
-			spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath,
+			spec, err := c.sandboxContainerSpec(context.Background(), testID, config, imageConfig, nsPath,
 				test.podAnnotations)
 			if test.expectErr {
 				assert.Error(t, err)

--- a/internal/cri/server/podsandbox/sandbox_run_windows.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows.go
@@ -17,6 +17,7 @@
 package podsandbox
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -31,7 +32,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/util"
 )
 
-func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
+func (c *Controller) sandboxContainerSpec(ctx context.Context, id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	specOpts := []oci.SpecOpts{
@@ -84,7 +85,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	specOpts = append(specOpts, customopts.WithAnnotation(annotations.WindowsHostProcess, strconv.FormatBool(config.GetWindows().GetSecurityContext().GetHostProcess())))
 
 	specOpts = append(specOpts,
-		annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...,
+		annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(ctx, config), config, true)...,
 	)
 
 	return c.runtimeSpec(id, "", specOpts...)

--- a/internal/cri/server/podsandbox/sandbox_run_windows_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows_test.go
@@ -17,6 +17,7 @@
 package podsandbox
 
 import (
+	"context"
 	"testing"
 
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -102,7 +103,7 @@ func TestSandboxWindowsNetworkNamespace(t *testing.T) {
 	c := newControllerService()
 
 	config, imageConfig, specCheck := getRunPodSandboxTestData(c.config)
-	spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
+	spec, err := c.sandboxContainerSpec(context.Background(), testID, config, imageConfig, nsPath, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, spec)


### PR DESCRIPTION
Allows overriding the sandbox image per-pod. This makes it possible for pods running with the overlaybd snapshotter to specify the pause image as an overlaybd image, which ensures that it will be created as a block device and will work with firecracker (which only supports block devices).